### PR TITLE
converted task to multitask and passed through fully grunt configuration...

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -2,8 +2,17 @@ module.exports = function(grunt) {
 
   grunt.initConfig({
     'testem': {
-      files : [
+      files: [
         'path/to/test.html'
+      ],
+      routes: [
+        '/path': 'path/to/files'
+      ],
+      browsers: [
+        'chrome'
+      ],
+      src_files: [
+        'app/templates/**/*.tmpl'
       ]
     }
   });

--- a/tasks/testem.js
+++ b/tasks/testem.js
@@ -13,14 +13,14 @@ module.exports = function(grunt) {
       async = require('async'),
       fs = require('fs');
   
-  grunt.registerTask( 'testem', 'Execute testem.', function() {
-    
+  grunt.registerMultiTask( 'testem', 'Execute testem.', function() {
     var done = this.async(),
-      browsers = grunt.config('testem.browsers')||[],
+      that = this,
+      browsers = this.data.browsers||[],
       ci = (browsers.length) ? ' -l ' + browsers.join(',') : '';
-    
+
     async.reduce(
-      grunt.config('testem.files'),
+      that.data.files,
       {
         pass : 0,
         fail : 0,
@@ -28,9 +28,9 @@ module.exports = function(grunt) {
         tests : 0
       },
       function(memo, path, callback){
-        fs.writeFileSync('testem.json', '{"test_page":"'+path+'"}');
-        grunt.log.writeln( 'testem ci'+ci );
-        exec( 'testem ci'+ci, {}, function( code, stdout, stderr ){
+        that.data['test_page'] = path;
+        fs.writeFileSync('testem.json', JSON.stringify(that.data));
+        exec('testem ci'+ci, {}, function( code, stdout, stderr ){
           var pass = (stdout.match(/\nok \d+ - [^\n]+/g)||[]).length,
             not = (stdout.match(/\nnot ok \d+ - [^\n]+/g)||[]),
             fail = not.length,


### PR DESCRIPTION
To offer more flexibility in using this grunt plugin with Testem I'm made a few changes. 
- Converted registerTask to registerMultiTask to allow for passing of configuration object from project grunt file
- Wrote above config object into the testme.json so we have fully control on how testem runs
