### PR TITLE
Preserve new lines when test fails

### DIFF
--- a/tasks/testem.js
+++ b/tasks/testem.js
@@ -45,7 +45,7 @@ module.exports = function(grunt) {
         var matches={};
         data = ''+data;
         matches.path = data.match(/^# Executing (.+)$/);
-        matches.fail = data.match(/^not ok (.+)/);
+        matches.fail = data.match(/^not ok ([\s\S]+)/);
         if(matches.path){
           grunt.log.writeln(matches.path[0]);
         }


### PR DESCRIPTION
In some cases the error message might span on multiple lines.

The `.` in JavaScript regular expressions does not match new lines.

This makes failures more descriptive
