### PR TITLE
Documentation on code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .DS_Store
 .gitignore
 npm-debug.log
+examples/coverage/tmp
+examples/coverage/instrumented

--- a/README.md
+++ b/README.md
@@ -49,3 +49,22 @@ TAP file path
 ### Options
 See also [Configuration File](https://github.com/airportyh/testem#configuration-file)
 
+It also accepts an `output.coverage` option that is the folder path where coverage reports are written.
+
+```js
+grunt.initConfig({
+  'testem': {
+    options : {
+      output: {
+        coverage : 'coverage-results/'
+      }
+    },
+    main : {
+      src: [ 'examples/*.html' ],
+      dest: 'tests.tap'
+    }
+  }
+});
+```
+
+Source files must be instrumented before running tests. An example on how to do it in grunt is available inside `examples/coverage`.

--- a/examples/coverage/Gruntfile.js
+++ b/examples/coverage/Gruntfile.js
@@ -1,0 +1,54 @@
+module.exports = function(grunt) {
+  "use strict";
+
+  grunt.initConfig({
+    testem: {
+      options : {
+        launch_in_ci : ['Chrome'],
+        output: {
+          coverage: 'tmp/coverage/from_browsers/'
+        },
+        routes: {
+          "/lib": "../lib",
+          "/src": "instrumented"
+        }
+      },
+      all : {
+        files : {
+          'tmp/result.tap': ['test/index.html']
+        }
+      }
+    },
+
+    clean: {
+      tests: ['tmp']
+    },
+
+    // This section is to instrument files from grunt
+    shell: {
+      instrument: {
+        command: "istanbul instrument --output instrumented src"
+      },
+      report: {
+        command: "istanbul report --root tmp/coverage/from_browsers --dir tmp/coverage lcov"
+      },
+      options: {
+        stdout: true,
+        failOnError: true
+      }
+    }
+  });
+
+  // In real life replace this line:
+  grunt.loadTasks('../../tasks');
+  // with
+  // grunt.loadNpmTasks('grunt-testem');
+
+  grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.loadNpmTasks('grunt-shell');
+  
+
+  grunt.registerTask('test', ['clean', 'shell:instrument', 'testem', 'shell:report']);
+  grunt.registerTask('default', ['test']);
+
+};

--- a/examples/coverage/package.json
+++ b/examples/coverage/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "grunt-testem-coverage-example",
+  "description": "A grunt plugin for testem using code coverage.",
+  "version": "0.0.0-whatever",
+  "homepage": "https://github.com/sideroad/grunt-testem",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/sideroad/grunt-testem.git"
+  },
+  "dependencies": {
+    "async": "~0.1.22",
+    "underscore": "~1.4.2",
+    "testem-multi": "~0.3.1",
+    "grunt-contrib-clean": "~0.4.0",
+    "grunt": "~0.4.2",
+    "grunt-shell": "~0.6.4"
+  }
+}

--- a/examples/coverage/src/hello.js
+++ b/examples/coverage/src/hello.js
@@ -1,0 +1,3 @@
+function sayHello (name, capital) {
+	return "Hello " + (!!capital ? name.toUpperCase() : name);
+}

--- a/examples/coverage/test/index.html
+++ b/examples/coverage/test/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>QUnit Example</title>
+  <link rel="stylesheet" href="../../lib/qunit.css">
+</head>
+<body>
+  <div id="qunit"></div>
+  <script src="../../lib/qunit.js"></script>
+  <script src="/testem.js"></script>
+
+  <script src="../src/hello.js"></script>
+  <script>
+  test("say hello", function () {
+  	equal(sayHello("testem-multi", true), "Hello TESTEM-MULTI");
+  })
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "async": "~0.1.22",
     "underscore": "~1.4.2",
-    "testem-multi": "~0.4.1"
+    "testem-multi": "~0.4.2"
   },
   "devDependencies": {
     "grunt-contrib-clean": "~0.4.0",


### PR DESCRIPTION
I updated the README to explain how to write code coverage reports with grunt-testem.

This PR depends on sideroad/testem-multi#6. 
Once that PR is merged and the new version is published in npm, this can work.

There's also an example on how to configure grunt + istanbul to instrument and generate a report.

I've marked this version as `0.5.0` because now `grunt-testem` depends on `testem-multi` 0.4.x and not anymore on 0.3.x but there's no backward incompatible change, so if you prefer we can call it `0.4.1`
