### PR TITLE
Use grunt instead of fs and update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-testem",
   "description": "A grunt plugin for testem.",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "homepage": "https://github.com/sideroad/grunt-testem",
   "author": "sideroad <sideroad.jp@gmail.com> (http://sideroad.secret.jp/)",
   "repository": {
@@ -32,13 +32,13 @@
     "test": "grunt test --verbose --force"
   },
   "dependencies": {
-    "async": "~0.1.22",
-    "underscore": "~1.4.2",
+    "async": "~0.9.0",
+    "underscore": "~1.6.0",
     "testem-multi": "~0.4.2"
   },
   "devDependencies": {
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-nodeunit": "~0.4.1",
     "grunt": "~0.4.0"
   },
   "peerDependencies": {

--- a/tasks/testem.js
+++ b/tasks/testem.js
@@ -11,8 +11,7 @@ module.exports = function(grunt) {
   "use strict";
 
   var async = require('async'),
-      _ = require('underscore'),
-      fs = require('fs');
+      _ = require('underscore');
 
   grunt.registerMultiTask( 'testem', 'Execute testem.', function() {
     var done = this.async(),
@@ -21,7 +20,7 @@ module.exports = function(grunt) {
       files = [];
 
     if(options.json){
-      options = _.extend({}, JSON.parse( fs.readFileSync(options.json, 'utf-8').replace(/\n/,'')), options);
+      options = _.extend({}, grunt.file.readJSON(options.json), options);
     }
     grunt.log.writeln('Now testing...');
 
@@ -61,7 +60,7 @@ module.exports = function(grunt) {
             fail = memo.fail;
 
         if(tap){
-          fs.writeFileSync(tap, results, 'utf-8');
+          grunt.file.write(tap, results);
         }
         if( tests != pass ||
             fail ) {


### PR DESCRIPTION
`fs.writeFileSync` fails if the destination folder does not exists.

I've replaced it with `grunt.file.write` which instead creates the folder before writing the file.

I've also updated some dependencies.
